### PR TITLE
notation on large boards

### DIFF
--- a/lib/src/model/board_size.dart
+++ b/lib/src/model/board_size.dart
@@ -90,26 +90,30 @@ class BoardSize {
   /// Create a `Move` from an algebraic string (e.g. a2a3, g6f3) for a board
   /// of this size.
   Move moveFromAlgebraic(String alg) {
+    List<String> sections = alg.split('/');
+    alg = sections[0];
     if (alg[1] == '@') {
       // it's a drop
       int from = Squares.hand;
-      int to = squareNumber(alg.substring(2, 4));
+      int to = squareNumber(alg.substring(2));
       return Move(from: from, to: to, piece: alg[0]);
     }
-    int from = squareNumber(alg.substring(0, 2));
-    int to = squareNumber(alg.substring(2, 4));
-
     String? piece;
     int? gatingSquare;
     String? promo;
-    List<String> sections = alg.split('/');
+    int f1 = alg.indexOf(RegExp(r'[a-zA-Z]'), 1);
+    int f2 = alg.indexOf(RegExp(r'[a-zA-Z]'), f1 + 1);
+
+    int from = squareNumber(alg.substring(0, f1));
+    int to = squareNumber(alg.substring(f1, f2 == -1 ? null : f2));
+
     if (sections.length > 1) {
       String gate = sections.last;
       piece = gate[0];
       gatingSquare =
           gate.length > 2 ? squareNumber(gate.substring(1, 3)) : from;
-    } else {
-      promo = (alg.length > 4) ? alg[4] : null;
+    } else if (f2 > -1) {
+      promo = alg.substring(f2);
     }
 
     return Move(

--- a/lib/src/ui/board_controller.dart
+++ b/lib/src/ui/board_controller.dart
@@ -371,6 +371,14 @@ class _BoardControllerState extends State<BoardController> {
     if (gate) {
       pieces.insert(0, null);
     }
+    //if exists (pawn) move to square without promotion ?
+    if (!gate && moves.isNotEmpty) {
+      for (Move m in widget.moves) {
+        if (m.from == moves[0].from && m.to == square && m.promo == null) {
+          pieces.insert(0, null);
+        }
+      }
+    }
 
     setState(() {
       pieceSelectors.add(


### PR DESCRIPTION
The moveFromAlgebraic(String alg) function only works correctly on an 8x8 board because the length of the normal stroke notation is always assumed to be 4. However, it can be longer on a larger board (Grand Chess). For example, after move Rb1 (a1b1), Black can play Rb10 (a10b10). The error will show up in the complex example when Grand Chess is chosen and played with black pieces. 